### PR TITLE
Only show open issues & Allow aliases to use labels

### DIFF
--- a/files/default/treslek-gh-issue-search/index.js
+++ b/files/default/treslek-gh-issue-search/index.js
@@ -29,7 +29,7 @@ Object.keys(config.commands).forEach(function(repo) {
     }
 
     options = {
-      url: sprintf('https://%sapi.github.com/search/issues?q=repo:%s+%s', creds, settings.repo, encodeURIComponent(msg)),
+      url: sprintf('https://%sapi.github.com/search/issues?q=repo:%s+is:open+%s', creds, settings.repo, encodeURIComponent(msg)),
       headers: {
         'User-Agent': 'Roarbot'
       }

--- a/files/default/treslek-gh-issue-search/index.js
+++ b/files/default/treslek-gh-issue-search/index.js
@@ -22,6 +22,7 @@ Object.keys(config.commands).forEach(function(repo) {
   IssueSearch.prototype[repo] = function(bot, to, from, msg, callback) {
     var settings = config.commands[repo],
         creds ='',
+        label = settings.label ? 'label:'+ settings.label : '',
         intervalId, options;
 
     if (settings.username && settings.password) {
@@ -29,7 +30,7 @@ Object.keys(config.commands).forEach(function(repo) {
     }
 
     options = {
-      url: sprintf('https://%sapi.github.com/search/issues?q=repo:%s+is:open+%s', creds, settings.repo, encodeURIComponent(msg)),
+      url: sprintf('https://%sapi.github.com/search/issues?q=repo:%s+is:open+%s+%s', creds, settings.repo, label, encodeURIComponent(msg)),
       headers: {
         'User-Agent': 'Roarbot'
       }

--- a/templates/default/treslek-gh-issue-search.json.erb
+++ b/templates/default/treslek-gh-issue-search.json.erb
@@ -5,6 +5,29 @@
       "username": "<%= @username %>",
       "password": "<%= @password %>"
     },
+    "ele-kb": {
+      "repo": "racker/ele-kb",
+      "username": "<%= @username %>",
+      "password": "<%= @password %>"
+    },
+    "runbook": {
+      "repo": "racker/ele-kb",
+      "username": "<%= @username %>",
+      "password": "<%= @password %>",
+      "label": "runbook"
+    },
+    "elerunbook": {
+      "repo": "racker/ele-kb",
+      "username": "<%= @username %>",
+      "password": "<%= @password %>",
+      "label": "runbook"
+    },
+    "ele-runbook": {
+      "repo": "racker/ele-kb",
+      "username": "<%= @username %>",
+      "password": "<%= @password %>",
+      "label": "runbook"
+    },
     "ele": {
       "repo": "racker/ele",
       "username": "<%= @username %>",


### PR DESCRIPTION
Gets rid of all the unwanted closed issues that show up when we search.

Also adds an option to specify a label to filter by in the config.
