### PR TITLE
fix conf.json

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['treslek']['user'] = 'treslek'
 # install path
 default['treslek']['path'] = '/usr/local/treslek'
 default['treslek']['bin'] = "#{node['treslek']['path']}/bin/treslek.js"
-default['treslek']['config'] = '/etc/treslek/config.json'
+default['treslek']['config'] = '/etc/treslek/conf.json'
 
 # git code repository
 default['treslek']['repo'] = 'https://github.com/jirwin/treslek'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'michael@mirwin.net'
 license          'Apache 2.0'
 description      'Installs/Configures the Treslek IRC bot'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.5'
+version          '1.3.6'
 
 recipe           'treslek::default', 'Installs and configures Treslek'
 

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -15,7 +15,7 @@ describe 'treslek::default' do
   end
 
   it 'creates config file' do
-    expect(chef_run).to create_template('/etc/treslek/config.json')
+    expect(chef_run).to create_template('/etc/treslek/conf.json')
   end
 
   it 'creates config file' do


### PR DESCRIPTION
fixes https://github.com/racker/chef/issues/4199

# What

Fix default path for treslek config.

# TODO
Does the gh-search-plugin also assume `conf.json` versus `config.json`?