### PR TITLE
allow for configurable runit user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.0
+* allow for configurable runit user
+
 # 1.3.5
 * Fix config path
 
@@ -15,7 +18,7 @@
 # 1.2.1
 * CI tooling and lint cleanup
 
-# 1.2.0 
+# 1.2.0
 * Merge of mburns/cookbook-treslek and mmi-cookbooks/treslek-chef
 
 # 0.2.1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,4 @@ default['treslek']['commandPrefix'] = '!'
 # runit config
 default['treslek']['keep_logs'] = 20
 default['treslek']['syslog_sink'] = '127.0.0.1:8001'
+default['treslek']['runit']['user'] = 'daemon'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'michael@mirwin.net'
 license          'Apache 2.0'
 description      'Installs/Configures the Treslek IRC bot'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.9'
+version          '1.4.0'
 
 recipe           'treslek::default', 'Installs and configures Treslek'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,8 +98,8 @@ template node['treslek']['config'] do
 end
 
 runit_service 'treslek' do
-  owner node['treslek']['user']
-  group node['treslek']['user']
+  owner node['treslek']['runit']['user']
+  group node['treslek']['runit']['user']
   # start_down node['treslek']['disable']
 end
 


### PR DESCRIPTION
As is, this cookbook breaks runit's ability to log due to the ownership of `log/main` and the app never starts up correctly.